### PR TITLE
Update Dozzle addon to version 8.14.3

### DIFF
--- a/dozzle/build.yaml
+++ b/dozzle/build.yaml
@@ -2,4 +2,4 @@ build_from:
   aarch64: ghcr.io/hassio-addons/base:18.1.3
   amd64: ghcr.io/hassio-addons/base:18.1.3
   armv7: ghcr.io/hassio-addons/base:18.1.3
-version: "8.14.2"
+version: "8.14.3"

--- a/dozzle/config.yaml
+++ b/dozzle/config.yaml
@@ -1,5 +1,5 @@
 name: "Dozzle"
-version: "8.14.2"
+version: "8.14.3"
 slug: "dozzle"
 description: "A simple, lightweight application that provides you with a web based interface to monitor your Docker container logs live."
 url: "https://dozzle.dev"


### PR DESCRIPTION
bump branch up from new dozzle build. This is absolutely not the way I should do this